### PR TITLE
feat(app): 全国平均API連携

### DIFF
--- a/app/src/main/java/com/kinu1024hoge/karaokechallenge/data/ApiService.kt
+++ b/app/src/main/java/com/kinu1024hoge/karaokechallenge/data/ApiService.kt
@@ -1,9 +1,27 @@
 package com.kinu1024hoge.karaokechallenge.data
 
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 
 data class PingResponse(val message: String)
 data class PromptDto(val id: Int, val content: String)
+
+data class ScorePostBody(val promptId: Int, val score: Int)
+
+data class ScoreStatsDto(
+    val count: Int,
+    val avg: Double?,   // データなしなら null
+    val min: Int?,
+    val max: Int?
+)
+
+data class ScorePostResponse(
+    val ok: Boolean,
+    val promptId: Int,
+    val yourScore: Int,
+    val stats: ScoreStatsDto
+)
 
 interface ApiService {
     @GET("ping")
@@ -11,4 +29,7 @@ interface ApiService {
 
     @GET("prompts/random")
     suspend fun getRandomPrompt(): PromptDto
+
+    @POST("scores")
+    suspend fun postScore(@Body body: ScorePostBody): ScorePostResponse
 }

--- a/app/src/main/java/com/kinu1024hoge/karaokechallenge/feature/result/ResultScreen.kt
+++ b/app/src/main/java/com/kinu1024hoge/karaokechallenge/feature/result/ResultScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.unit.dp
 fun ResultScreen(
     promptId: Int,
     score: Int,
+    avg: Float?,   // 全国平均（null の場合はデータなし）
+    count: Int,    // 集計件数（n）
     onBackHome: () -> Unit
 ) {
     val message = when {
@@ -28,6 +30,7 @@ fun ResultScreen(
         score >= 50 -> "まあまあ！次はもっとがんばろう！"
         else -> "挑戦したことに意味がある！次回に期待！"
     }
+    val avgText = avg?.let { String.format("%.1f", it) } ?: "--"
 
     Column(
         modifier = Modifier
@@ -49,10 +52,20 @@ fun ResultScreen(
         )
 
         Text(
-            text = "スコア: $score 点",
+            text = "あなたのスコア: $score 点",
             style = MaterialTheme.typography.headlineLarge,
             modifier = Modifier.padding(bottom = 16.dp),
             textAlign = TextAlign.Center
+        )
+
+        // ★ 全国平均の表示（データが無い場合は "--"、件数は n=0）
+        Text(
+            text = "全国平均: $avgText 点（n=$count）",
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp)
         )
 
         Text(
@@ -77,6 +90,8 @@ fun ResultScreenPreview() {
         ResultScreen(
             promptId = 1,
             score = 85,
+            avg = 76.5f,
+            count = 12,
             onBackHome = {}
         )
     }

--- a/app/src/main/java/com/kinu1024hoge/karaokechallenge/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/kinu1024hoge/karaokechallenge/navigation/AppNavGraph.kt
@@ -27,8 +27,8 @@ fun AppNavGraph() {
 
         composable(Destinations.CHALLENGE) {
             ChallengeScreen(
-                onCompleted = { promptId, score ->
-                    nav.navigate(Destinations.result(promptId, score))
+                onCompleted = { promptId, score, avg, count ->
+                    nav.navigate(Destinations.resultWithStats(promptId, score, avg, count))
                 },
                 onBack = { nav.popBackStack() }
             )
@@ -38,18 +38,23 @@ fun AppNavGraph() {
             route = Destinations.RESULT,
             arguments = listOf(
                 navArgument("promptId") { type = NavType.IntType },
-                navArgument("score")    { type = NavType.IntType; defaultValue = 0 },
+                navArgument("score")    { type = NavType.IntType },
+                navArgument("avg")      { type = NavType.FloatType; defaultValue = -1f },
+                navArgument("count")    { type = NavType.IntType;   defaultValue = 0  },
             )
         ) { backStackEntry ->
             val promptId = backStackEntry.arguments?.getInt("promptId") ?: 0
             val score    = backStackEntry.arguments?.getInt("score") ?: 0
+            val avgRaw   = backStackEntry.arguments?.getFloat("avg") ?: -1f
+            val count    = backStackEntry.arguments?.getInt("count") ?: 0
+            val avg: Float? = avgRaw.takeIf { it >= 0f } // -1f を null 扱い
 
             ResultScreen(
                 promptId = promptId,
-                score    = score,
-                onBackHome = {
-                    nav.popBackStack(Destinations.HOME, inclusive = false)
-                }
+                score = score,
+                avg = avg,
+                count = count,
+                onBackHome = { nav.popBackStack(Destinations.HOME, inclusive = false) }
             )
         }
     }

--- a/app/src/main/java/com/kinu1024hoge/karaokechallenge/navigation/Destinations.kt
+++ b/app/src/main/java/com/kinu1024hoge/karaokechallenge/navigation/Destinations.kt
@@ -5,6 +5,10 @@ object Destinations {
     const val CHALLENGE = "challenge"
     const val TESTPING = "testPing"
 
-    const val RESULT = "result/{promptId}/{score}"
-    fun result(promptId: Int, score: Int) = "result/$promptId/$score"
+    const val RESULT = "result/{promptId}/{score}/{avg}/{count}"
+
+    fun resultWithStats(promptId: Int, score: Int, avg: Float?, count: Int): String {
+        val safeAvg = avg ?: -1f
+        return "result/$promptId/$score/$safeAvg/$count"
+    }
 }


### PR DESCRIPTION
- nav: Destinations.RESULT を result/{promptId}/{score}/{avg}/{count} に変更
- nav: resultWithStats(promptId, score, avg?, count) ヘルパーを追加（avg=null は -1f で受け渡し）
- nav: AppNavGraph で Challenge → Result の遷移を 4引数へ統一
- challenge: ChallengeScreen の onCompleted を (promptId, score, avg?, count) に変更
- challenge: スコア確定時に POST /scores を実行し、レスポンスから avg/count を取得して遷移
- challenge: 二重送信防止の submitting フラグを追加、簡易リトライ（再読み込み）を整備
- result: ResultScreen を 4引数版に拡張し、全国平均と件数を表示（avg=null は "--", n=0 表示）

BREAKING CHANGE:
- ルート定義を 2 引数 → 4 引数に変更（result/{promptId}/{score}/{avg}/{count}）
- ChallengeScreen の onCompleted シグネチャを (Int, Int) → (Int, Int, Float?, Int) に変更 → 呼び出し側は resultWithStats(...) を用いて遷移すること